### PR TITLE
Fix: Resolve production URL issue for recurring page

### DIFF
--- a/src/app/recurring/page.tsx
+++ b/src/app/recurring/page.tsx
@@ -4,12 +4,16 @@ import { Navigation } from '@/components/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 async function getCategories() {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'}/api/categories`,
-    {
-      cache: 'no-store',
-    }
-  );
+  // For server-side rendering, construct the full URL
+  const baseUrl =
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    (process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : 'http://localhost:3000');
+
+  const response = await fetch(`${baseUrl}/api/categories`, {
+    cache: 'no-store',
+  });
 
   if (!response.ok) {
     throw new Error('Failed to fetch categories');


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes the `ECONNREFUSED 127.0.0.1:3000` error that occurred when accessing the recurring transactions page in production on Vercel.

## 🔍 Problem

The recurring page was using a hardcoded `localhost:3000` URL as a fallback when `NEXT_PUBLIC_BASE_URL` wasn't set, causing fetch requests to fail in production:

```
⨯ TypeError: fetch failed
  [cause]: Error: connect ECONNREFUSED 127.0.0.1:3000
```

## ✅ Solution

- Updated the `getCategories()` function to properly construct URLs for production
- Added fallback to `VERCEL_URL` environment variable (automatically provided by Vercel)
- Maintains compatibility with local development environment
- Uses the pattern: `NEXT_PUBLIC_BASE_URL` → `https://${VERCEL_URL}` → `http://localhost:3000`

## 🧪 Testing

- ✅ Local development continues to work with `localhost:3000`
- ✅ Production deployments will use the proper Vercel URL
- ✅ Custom domain setups can still use `NEXT_PUBLIC_BASE_URL` if needed

## 📝 Changes

- Modified `src/app/recurring/page.tsx` to use proper URL construction for server-side API calls

## 🚀 Deploy Instructions

After merging, this fix will automatically resolve the production issue. No additional environment variables need to be configured.